### PR TITLE
Update to use core hooks for compendium & sidebar context options, fix dnd5e compatibility

### DIFF
--- a/scripts/dnd5e-compatibility.js
+++ b/scripts/dnd5e-compatibility.js
@@ -14,15 +14,15 @@ export const dnd5eRollItem = (item, actor, actorHasItem) => {
     if (item.labels?.save && item.labels.save.includes('DC  '))
       item.labels.save = item.labels.save.replace('DC  ', `DC ${dc} `)
   }
-  if (!event.altKey && window.BetterRolls) {
+  if (!event?.altKey && window.BetterRolls) {
     const customRollItem = BetterRolls.rollItem(item, { event: event, preset: 0 })
     customRollItem.consumeCharge = () => Promise.resolve(true)
     return customRollItem.toMessage()
   }
-  return item.roll().then(chatDataOrMessage => {
+  return item.use().then(chatDataOrMessage => {
     if (!chatDataOrMessage) return chatDataOrMessage
     // embed the item data in the chat message
-    chatDataOrMessage.setFlag('dnd5e', 'itemData', item.data)
+    chatDataOrMessage.setFlag('dnd5e', 'itemData', item.toObject(false))
     return chatDataOrMessage
   })
 }
@@ -60,7 +60,7 @@ export const dnd5eInitializeDummyActor = async (compendiumRollActor) => {
 let isQuickCasting = false
 export const DND5e_AbilityUseDialog__getSpellData_Wrapper = (originalFunction, actorData, itemData, data, ...args) => {
   const mergedData = originalFunction(actorData, itemData, data, ...args)  // same data object;  mutated argument!
-  if (mergedData?.item?.document?.actor?.name === DUMMY_ACTOR_NAME) {
+  if (mergedData?.item?.actor?.name === DUMMY_ACTOR_NAME) {
     for (const spLev of mergedData.spellLevels) { spLev.hasSlots = true }
     mergedData.errors = ['Quick Roll To Chat: no real slots will be used']
     isQuickCasting = true
@@ -69,8 +69,8 @@ export const DND5e_AbilityUseDialog__getSpellData_Wrapper = (originalFunction, a
 }
 export const DND5e_AbilityUseDialog_create_Wrapper = async (originalFunction, item, ...args) => {
   const formResult = await originalFunction(item, ...args)
-  if (isQuickCasting) {
-    formResult.consumeSlot = false
+  if (formResult && isQuickCasting) {
+    formResult.consumeSpellSlot = false
   }
   return formResult
 }

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -1,7 +1,7 @@
 import {
   addButtonToSheetHeader,
-  Compendium__getEntryContextOptions_Wrapper,
-  SidebarDirectory__getEntryContextOptions_Wrapper,
+  addCompendiumContextOptions,
+  addSidebarContextOptions,
 } from './menu-buttons.js'
 import { MODULE_ID, MODULE_NAME } from './consts.js'
 import {
@@ -26,28 +26,16 @@ Hooks.once('init', function () {
 })
 
 Hooks.once('setup', function () {
-  libWrapper.register(
-    MODULE_ID,
-    'Compendium.prototype._getEntryContextOptions',
-    Compendium__getEntryContextOptions_Wrapper,
-    'WRAPPER',
-  )
-  libWrapper.register(
-    MODULE_ID,
-    `SidebarDirectory.prototype._getEntryContextOptions`,
-    SidebarDirectory__getEntryContextOptions_Wrapper,
-    'WRAPPER',
-  )
-  if (game?.dnd5e?.applications?.AbilityUseDialog?._getSpellData) {
+  if (dnd5e?.applications?.item?.AbilityUseDialog?._getSpellData) {
     libWrapper.register(
       MODULE_ID,
-      `game.dnd5e.applications.AbilityUseDialog._getSpellData`,
+      `dnd5e.applications.item.AbilityUseDialog._getSpellData`,
       DND5e_AbilityUseDialog__getSpellData_Wrapper,
       'WRAPPER',
     )
     libWrapper.register(
       MODULE_ID,
-      `game.dnd5e.applications.AbilityUseDialog.create`,
+      `dnd5e.applications.item.AbilityUseDialog.create`,
       DND5e_AbilityUseDialog_create_Wrapper,
       'WRAPPER',
     )
@@ -55,5 +43,7 @@ Hooks.once('setup', function () {
   Hooks.on('getItemSheetHeaderButtons', addButtonToSheetHeader)
   Hooks.on('getActorSheetHeaderButtons', addButtonToSheetHeader)
   Hooks.on('getJournalSheetHeaderButtons', addButtonToSheetHeader)
+  Hooks.on("getCompendiumEntryContext", addCompendiumContextOptions)
+  Hooks.on("getSidebarTabEntryContext", addSidebarContextOptions)
   console.log(`${MODULE_NAME} | Done setting up.`)
 })

--- a/scripts/menu-buttons.js
+++ b/scripts/menu-buttons.js
@@ -28,23 +28,21 @@ export function addButtonToSheetHeader (sheet, buttons) {
   return buttons
 }
 
-export function Compendium__getEntryContextOptions_Wrapper (wrapped) {
-  const buttons = wrapped.bind(this)()
-  const documentName = this.collection.documentName
-  if (!COMPATIBLE_DOCUMENT_TYPES.includes(documentName)) {
-    return buttons
-  }
+export function addCompendiumContextOptions (application, buttons) {
+  const pack = game.packs.get(application[0].dataset.pack);
+  const documentName = pack?.metadata.type
+  if (!pack || !COMPATIBLE_DOCUMENT_TYPES.includes(documentName)) return
 
   // Add a Sheet To Chat button
   buttons.unshift({
-    name: getRollActionName(documentName, guessCompendiumSubtype(this.collection.metadata)),
+    name: getRollActionName(documentName, guessCompendiumSubtype(pack.metadata)),
     class: 'sheet-to-chat',
     icon: '<i class="fas fa-dice-d20"></i>',
     callback: async li => {
       const mouseEvent = event
       const entryId = li.data('documentId')
-      const thumbImg = this.collection.index.get(entryId).thumb
-      return this.collection.getDocument(entryId).then(async item => {
+      const thumbImg = pack.index.get(entryId).thumb
+      return pack.getDocument(entryId).then(async item => {
         if (item.img?.includes('default-icons') && thumbImg) {
           // little trick to use the trick that PF2e modules use, which updates thumbnail images but not data images
           await quickRollToChat(item, mouseEvent, thumbImg)
@@ -53,15 +51,13 @@ export function Compendium__getEntryContextOptions_Wrapper (wrapped) {
       })
     },
   })
-  return buttons
 }
 
-export function SidebarDirectory__getEntryContextOptions_Wrapper (wrapped) {
-  const buttons = wrapped.bind(this)()
-  const documentName = this.constructor.documentName
-  if (!COMPATIBLE_DOCUMENT_TYPES.includes(documentName)) {
-    return buttons
-  }
+
+export function addSidebarContextOptions (application, buttons) {
+  const tab = ui[application[0].dataset.tab]
+  const documentName = tab?.constructor.documentName
+  if (!COMPATIBLE_DOCUMENT_TYPES.includes(documentName)) return
 
   // Add a Sheet To Chat button
   buttons.unshift({
@@ -76,5 +72,4 @@ export function SidebarDirectory__getEntryContextOptions_Wrapper (wrapped) {
       return false
     },
   })
-  return buttons
 }

--- a/scripts/quick-roll-to-chat.js
+++ b/scripts/quick-roll-to-chat.js
@@ -51,7 +51,7 @@ async function rollRollableTable (item) {
 }
 
 export async function rollItem (item, event) {
-  event && event.preventDefault()
+  event?.preventDefault()
   if (dummyActor === null) {
     dummyActor = await findOrCreateDummyActor()
   }
@@ -200,7 +200,7 @@ export const getRollActionName = (documentName, documentSubtype) => {
 }
 
 export const guessCompendiumSubtype = (compendiumMetadata) => {
-  const packageName = compendiumMetadata.package
+  const packageName = compendiumMetadata.packageName
   const name = compendiumMetadata.name.toLowerCase()
   if (packageName === 'pf2e') {
     if (name.includes('iconics')) return 'character'


### PR DESCRIPTION
- Switch to core `getCompendiumEntryContext` & `getSidebarTabEntryContext` hooks
- Fix issue with infinite recursion while building chat data for 5e
- Fix issue with spell slot consumption while casting in 5e
- Fix issue with getting compendium subtype in pf2e