### PR TITLE
Replace AbilityUseDialog patches with hooks

### DIFF
--- a/module.json
+++ b/module.json
@@ -26,19 +26,6 @@
       "reddit": "u/Shemetz"
     }
   ],
-  "relationships": {
-    "requires": [
-      {
-        "id": "lib-wrapper",
-        "type": "module",
-        "manifest": "https://github.com/ruipin/fvtt-lib-wrapper/releases/latest/download/module.json",
-        "compatibility": {
-          "minimum": "1.0.0.0",
-          "verified": "1.12.6.0"
-        }
-      }
-    ]
-  },
   "manifestPlusVersion": "1.2.0",
   "media": [
     {

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -5,8 +5,8 @@ import {
 } from './menu-buttons.js'
 import { MODULE_ID, MODULE_NAME } from './consts.js'
 import {
-  DND5e_AbilityUseDialog__getSpellData_Wrapper,
-  DND5e_AbilityUseDialog_create_Wrapper
+  abilityUseRenderHook,
+  abilityUseQuickCastingHook
 } from './dnd5e-compatibility.js'
 
 Hooks.once('init', function () {
@@ -27,18 +27,8 @@ Hooks.once('init', function () {
 
 Hooks.once('setup', function () {
   if (game?.dnd5e?.applications?.item?.AbilityUseDialog?._getSpellData) {
-    libWrapper.register(
-      MODULE_ID,
-      `dnd5e.applications.item.AbilityUseDialog._getSpellData`,
-      DND5e_AbilityUseDialog__getSpellData_Wrapper,
-      'WRAPPER',
-    )
-    libWrapper.register(
-      MODULE_ID,
-      `dnd5e.applications.item.AbilityUseDialog.create`,
-      DND5e_AbilityUseDialog_create_Wrapper,
-      'WRAPPER',
-    )
+    Hooks.on('renderAbilityUseDialog', abilityUseRenderHook)
+    Hooks.on('dnd5e.preItemUsageConsumption', abilityUseQuickCastingHook)
   }
   Hooks.on('getItemSheetHeaderButtons', addButtonToSheetHeader)
   Hooks.on('getActorSheetHeaderButtons', addButtonToSheetHeader)


### PR DESCRIPTION
I decided to see if I could replace those last two libWrapper patched methods with hooks. The lack of a `preRender` hook for applications meant that I had to do a bit of DOM manipulation to adjust the dialog, but everything seems to work out.