### PR TITLE
Pf2e fix

### DIFF
--- a/scripts/compatibility/pf2e-compatibility.js
+++ b/scripts/compatibility/pf2e-compatibility.js
@@ -151,7 +151,7 @@ ${spellLevel}${th(spellLevel)} Level (+${spellLevel - item.level})
   contentDiv.innerHTML = content
 
   return await DialogV2.wait({
-    title: `Upcast ${item.name}`,
+    title: `Heighten ${item.name}`,
     content: contentDiv,
     buttons: [
       {


### PR DESCRIPTION
Fixes two issues in PF2e:
- Spells have been using the spellcasting tradition listed in the spellcasting entry of the dummy actor, which often is not a valid tradition for the spell. They should now use the first tradition listed on the spell, or `arcane` if none are found.
- The spell upcasting/heightening dialog was giving an error and not working.