### PR TITLE
PF2e: Do not change spellcasting tradition of non-dummy actors

### DIFF
--- a/scripts/compatibility/pf2e-compatibility.js
+++ b/scripts/compatibility/pf2e-compatibility.js
@@ -47,7 +47,7 @@ const getSpellcasting = (actor) => {
 
 export const pf2eCastSpell = async (item, actor) => {
   const spellcasting = getSpellcasting(actor)
-  if (actor.name === DUMMY_ACTOR_NAME) {
+  if (actor.name === DUMMY_ACTOR_NAME && actor.isOwner) {
     await spellcasting.update({
       "system.tradition.value": item.system.traits?.traditions?.[0] ?? 'arcane'
     })


### PR DESCRIPTION
As discussed in #33, prevents the module from changing spellcasting tradition of real actors in the pf2e system. Only the dummy actor should be modified to fix spell traits. This does allow for spells to be sent to chat with incorrect traits, but that's far better than messing with real actor data.