### PR TITLE
If a spell is contained in an actor, always use that actor

### DIFF
--- a/scripts/quick-send-to-chat.js
+++ b/scripts/quick-send-to-chat.js
@@ -194,14 +194,18 @@ function deactivateUglyHackThatLinksItemToActor (item, actor) {
 }
 
 export async function rollItem (item) {
-  const controlledActor = canvas.tokens.controlled[0]?.actor
-  if (game.settings.get(MODULE_ID, 'use-dummy-actor') === false) {
-    return rollDependingOnSystem(item, controlledActor, undefined)
+  let actorUuid = item.uuid.match(/Actor\.[^\.]+/)?.[0]
+  let actor = actorUuid ? await fromUuid(actorUuid) : undefined
+  if (actor === undefined) {
+    const controlledActor = canvas.tokens.controlled[0]?.actor
+    if (game.settings.get(MODULE_ID, 'use-dummy-actor') === false) {
+      return rollDependingOnSystem(item, controlledActor, undefined)
+    }
+    if (dummyActor === null) {
+      dummyActor = await findOrCreateDummyActor()
+    }
+    actor = controlledActor ?? dummyActor
   }
-  if (dummyActor === null) {
-    dummyActor = await findOrCreateDummyActor()
-  }
-  let actor = controlledActor ?? dummyActor
   if (game.system.id === 'pf2e' && item.type === 'spell' && actor.spellcasting.regular.length === 0) {
     // in pf2e, casting spells requires an actor with spellcasting, so sometimes we need to still use dummy actor
     actor = dummyActor


### PR DESCRIPTION
This adds a method for the module to discover the actor which contains a spell. A spell with uuid `Actor.JZ6mkE1nHNnqpDBZ.Item.iUDZ1dyHUUPlQQgA` will be sent to chat using the actor identified by uuid `Actor.JZ6mkE1nHNnqpDBZ`.

The actor selection priorities for a spell are:
1. If the spell item lives inside an actor, then use that actor.
2. If any tokens are controlled, use the actor from one of them.
3. If the dummy actor is enabled, create/use the dummy actor.

It's my understanding that the uuid format `Actor.[ActorID].Item.[ItemID]` is system and language agnostic. I have not tested in any system besides pf2e, or any language besides English.